### PR TITLE
Add simple web-based soundboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Soundboard
+
+This repository contains a simple web-based soundboard application.
+
+## Running
+
+Open `public/index.html` in any modern web browser. No additional setup is required.
+
+## Features
+
+- Load MP3 or WAV files from your computer.
+- Create multiple tabs to organize different sets of sounds.
+- Play several tracks at once and pause them individually.
+- Loop a track or jump back 5, 15, or 20 seconds.
+- Visual indicator showing whether a track is playing, paused, or stopped.
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Soundboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="tab-bar">
+        <button id="add-tab">+ Add Tab</button>
+    </div>
+    <div id="panels"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,122 @@
+let tabCounter = 0;
+const tabs = [];
+const tabBar = document.getElementById('tab-bar');
+const panels = document.getElementById('panels');
+const addTabBtn = document.getElementById('add-tab');
+
+addTabBtn.addEventListener('click', addTab);
+
+function addTab() {
+    const id = `tab-${tabCounter++}`;
+    const tabButton = document.createElement('button');
+    tabButton.textContent = `Tab ${tabCounter}`;
+    tabButton.dataset.target = id;
+    tabButton.addEventListener('click', () => activateTab(id));
+    tabBar.insertBefore(tabButton, addTabBtn);
+
+    const panel = document.createElement('div');
+    panel.className = 'tab-panel';
+    panel.id = id;
+
+    const addTrackBtn = document.createElement('button');
+    addTrackBtn.textContent = '+ Add Track';
+    addTrackBtn.addEventListener('click', () => addTrack(panel));
+    panel.appendChild(addTrackBtn);
+
+    panels.appendChild(panel);
+
+    activateTab(id);
+}
+
+function activateTab(id) {
+    document.querySelectorAll('#tab-bar button').forEach(btn => btn.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    const btn = Array.from(tabBar.children).find(b => b.dataset && b.dataset.target === id);
+    if (btn) btn.classList.add('active');
+    const panel = document.getElementById(id);
+    if (panel) panel.classList.add('active');
+}
+
+function addTrack(panel) {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'audio/*';
+    input.addEventListener('change', () => {
+        if (input.files.length > 0) {
+            createTrack(panel, input.files[0]);
+        }
+    });
+    input.click();
+}
+
+function createTrack(panel, file) {
+    const url = URL.createObjectURL(file);
+    const audio = new Audio(url);
+    audio.preload = 'auto';
+
+    const trackDiv = document.createElement('div');
+    trackDiv.className = 'track';
+
+    const title = document.createElement('span');
+    title.textContent = file.name;
+    trackDiv.appendChild(title);
+
+    const status = document.createElement('span');
+    status.className = 'status';
+    status.textContent = 'stopped';
+    trackDiv.appendChild(status);
+
+    const controls = document.createElement('div');
+    controls.className = 'controls';
+    trackDiv.appendChild(controls);
+
+    const playBtn = document.createElement('button');
+    playBtn.textContent = 'Play';
+    playBtn.addEventListener('click', () => {
+        if (audio.paused) {
+            audio.play();
+        } else {
+            audio.pause();
+        }
+    });
+    controls.appendChild(playBtn);
+
+    const loopBtn = document.createElement('button');
+    loopBtn.textContent = 'Loop';
+    loopBtn.addEventListener('click', () => {
+        audio.loop = !audio.loop;
+        loopBtn.classList.toggle('active', audio.loop);
+    });
+    controls.appendChild(loopBtn);
+
+    [5, 15, 20].forEach(sec => {
+        const btn = document.createElement('button');
+        btn.textContent = `- ${sec}s`;
+        btn.addEventListener('click', () => {
+            audio.currentTime = Math.max(audio.currentTime - sec, 0);
+        });
+        controls.appendChild(btn);
+    });
+
+    const pauseBtn = document.createElement('button');
+    pauseBtn.textContent = 'Pause';
+    pauseBtn.addEventListener('click', () => audio.pause());
+    controls.appendChild(pauseBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', () => {
+        audio.pause();
+        trackDiv.remove();
+    });
+    controls.appendChild(removeBtn);
+
+    audio.addEventListener('play', () => status.textContent = 'playing');
+    audio.addEventListener('pause', () => status.textContent = 'paused');
+    audio.addEventListener('ended', () => status.textContent = 'stopped');
+
+    panel.appendChild(trackDiv);
+}
+
+// Initialize with one tab
+addTab();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,49 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+#tab-bar {
+    display: flex;
+    background: #222;
+    color: white;
+    padding: 5px;
+}
+
+#tab-bar button {
+    margin-right: 5px;
+    padding: 5px 10px;
+    border: none;
+    background: #444;
+    color: white;
+    cursor: pointer;
+}
+
+#tab-bar button.active {
+    background: #666;
+}
+
+.tab-panel {
+    display: none;
+    padding: 10px;
+}
+
+.tab-panel.active {
+    display: block;
+}
+
+.track {
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.track .status {
+    font-weight: bold;
+    margin-left: 10px;
+}
+
+.controls button {
+    margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- add HTML/CSS/JS for a soundboard interface
- implement multiple tabs with audio tracks
- support play, pause, loop, rewind and removal
- document running the application

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687abd620910832f91d5123ad9a43c54