### PR TITLE
Add stop controls and time bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Soundboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div id="tab-bar">
-        <button id="add-tab">+ Add Tab</button>
+        <button id="add-tab" class="button is-small">+ Add Tab</button>
     </div>
     <div id="panels"></div>
     <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -6,9 +6,13 @@ const addTabBtn = document.getElementById('add-tab');
 
 addTabBtn.addEventListener('click', addTab);
 
+// Using the HTML5 Audio API keeps the implementation lightweight and
+// avoids the overhead of embedding full player widgets.
+
 function addTab() {
     const id = `tab-${tabCounter++}`;
     const tabButton = document.createElement('button');
+    tabButton.className = 'button is-small';
     tabButton.textContent = `Tab ${tabCounter}`;
     tabButton.dataset.target = id;
     tabButton.addEventListener('click', () => activateTab(id));
@@ -19,6 +23,7 @@ function addTab() {
     panel.id = id;
 
     const addTrackBtn = document.createElement('button');
+    addTrackBtn.className = 'button is-small';
     addTrackBtn.textContent = '+ Add Track';
     addTrackBtn.addEventListener('click', () => addTrack(panel));
     panel.appendChild(addTrackBtn);
@@ -67,10 +72,11 @@ function createTrack(panel, file) {
     trackDiv.appendChild(status);
 
     const controls = document.createElement('div');
-    controls.className = 'controls';
+    controls.className = 'controls buttons';
     trackDiv.appendChild(controls);
 
     const playBtn = document.createElement('button');
+    playBtn.className = 'button is-small';
     playBtn.textContent = 'Play';
     playBtn.addEventListener('click', () => {
         if (audio.paused) {
@@ -82,6 +88,7 @@ function createTrack(panel, file) {
     controls.appendChild(playBtn);
 
     const loopBtn = document.createElement('button');
+    loopBtn.className = 'button is-small';
     loopBtn.textContent = 'Loop: Off';
     loopBtn.addEventListener('click', () => {
         audio.loop = !audio.loop;
@@ -92,6 +99,7 @@ function createTrack(panel, file) {
 
     [5, 15, 20].forEach(sec => {
         const btn = document.createElement('button');
+        btn.className = 'button is-small';
         btn.textContent = `- ${sec}s`;
         btn.addEventListener('click', () => {
             audio.currentTime = Math.max(audio.currentTime - sec, 0);
@@ -100,11 +108,22 @@ function createTrack(panel, file) {
     });
 
     const pauseBtn = document.createElement('button');
+    pauseBtn.className = 'button is-small';
     pauseBtn.textContent = 'Pause';
     pauseBtn.addEventListener('click', () => audio.pause());
     controls.appendChild(pauseBtn);
 
+    const stopBtn = document.createElement('button');
+    stopBtn.className = 'button is-small';
+    stopBtn.textContent = 'Stop';
+    stopBtn.addEventListener('click', () => {
+        audio.pause();
+        audio.currentTime = 0;
+    });
+    controls.appendChild(stopBtn);
+
     const removeBtn = document.createElement('button');
+    removeBtn.className = 'button is-small is-danger';
     removeBtn.textContent = 'Remove';
     removeBtn.addEventListener('click', () => {
         audio.pause();
@@ -112,11 +131,47 @@ function createTrack(panel, file) {
     });
     controls.appendChild(removeBtn);
 
+    const progressContainer = document.createElement('div');
+    progressContainer.className = 'progress-container';
+    const progress = document.createElement('input');
+    progress.type = 'range';
+    progress.className = 'progress-bar';
+    progress.min = 0;
+    progress.value = 0;
+    progress.step = 0.01;
+    progressContainer.appendChild(progress);
+
+    const timeLabel = document.createElement('span');
+    timeLabel.className = 'time-label';
+    timeLabel.textContent = '0:00 / 0:00';
+    progressContainer.appendChild(timeLabel);
+    trackDiv.appendChild(progressContainer);
+
+    function updateProgress() {
+        progress.max = audio.duration || 0;
+        progress.value = audio.currentTime;
+        timeLabel.textContent = `${formatTime(audio.currentTime)} / ${formatTime(audio.duration)}`;
+    }
+
+    progress.addEventListener('input', () => {
+        audio.currentTime = progress.value;
+    });
+
+    audio.addEventListener('timeupdate', updateProgress);
+    audio.addEventListener('loadedmetadata', updateProgress);
+
     audio.addEventListener('play', () => status.textContent = 'playing');
     audio.addEventListener('pause', () => status.textContent = 'paused');
     audio.addEventListener('ended', () => status.textContent = 'stopped');
 
     panel.appendChild(trackDiv);
+}
+
+function formatTime(sec) {
+    if (isNaN(sec)) return '0:00';
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
 }
 
 // Initialize with one tab

--- a/public/style.css
+++ b/public/style.css
@@ -52,3 +52,19 @@ body {
     background: #008000;
     color: #fff;
 }
+
+.progress-container {
+    display: flex;
+    align-items: center;
+    margin-top: 5px;
+}
+
+.progress-bar {
+    flex: 1;
+    margin-right: 10px;
+}
+
+.time-label {
+    min-width: 60px;
+    text-align: right;
+}


### PR DESCRIPTION
## Summary
- add Bulma CSS to improve styling
- add stop button that resets the track
- show a progress bar with current time and duration
- style progress bar and buttons
- comment about use of HTML5 audio

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ac321cc6c832f9f2d9348278901d2