### PR TITLE
Persist soundboard state with localStorage

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -6,6 +6,7 @@ let audioElements = new Map();
 let tabData = new Map();
 let renamingTabId = null;
 let masterVolume = 1.0;
+const LOCAL_STORAGE_KEY = 'soundboardState';
 
 // Initialize first tab
 tabData.set(0, {
@@ -43,6 +44,7 @@ function confirmTabAction() {
             const tab = tabData.get(renamingTabId);
             tab.name = name;
             document.querySelector(`[data-tab="${renamingTabId}"] span`).textContent = name;
+            saveState();
         }
     } else {
         // Creating new tab
@@ -68,39 +70,37 @@ function closeTabModal() {
     renamingTabId = null;
 }
 
-function createTab(name) {
+function createTabElement(id, name) {
     const tabContainer = document.querySelector('.tab-container');
     const addTabBtn = document.querySelector('.add-tab');
-    
+
     const newTab = document.createElement('div');
     newTab.className = 'tab';
-    newTab.dataset.tab = tabCounter;
+    newTab.dataset.tab = id;
     newTab.innerHTML = `
         <span>${name}</span>
-        <button class="tab-close" onclick="removeTab(${tabCounter})">×</button>
+        <button class="tab-close" onclick="removeTab(${id})">×</button>
     `;
-    newTab.onclick = () => switchToTab(tabCounter);
-    
-    // Add double-click to rename
+    newTab.onclick = () => switchToTab(id);
+
     const tabSpan = newTab.querySelector('span');
     tabSpan.ondblclick = (e) => {
         e.stopPropagation();
-        renameTab(tabCounter);
+        renameTab(id);
     };
     tabSpan.style.cursor = 'pointer';
     tabSpan.title = 'Double-click to rename';
-    
+
     tabContainer.insertBefore(newTab, addTabBtn);
-    
-    // Create panel content
+
     const mainContent = document.querySelector('.main-content');
     const newPanel = document.createElement('div');
     newPanel.className = 'panel-content hidden';
-    newPanel.id = `panel-${tabCounter}`;
+    newPanel.id = `panel-${id}`;
     newPanel.innerHTML = `
-        <div class="sound-grid" id="grid-${tabCounter}">
+        <div class="sound-grid" id="grid-${id}">
             <div class="empty-slot">
-                <input type="file" accept=".mp3,.wav" onchange="loadSound(this, ${tabCounter})">
+                <input type="file" accept=".mp3,.wav" onchange="loadSound(this, ${id})">
                 <div class="empty-text">
                     <strong>Drop or Click</strong>
                     Add MP3/WAV file
@@ -109,15 +109,18 @@ function createTab(name) {
         </div>
     `;
     mainContent.appendChild(newPanel);
-    
-    // Initialize tab data
-    tabData.set(tabCounter, {
+
+    tabData.set(id, {
         name: name,
         sounds: new Map()
     });
-    
+}
+
+function createTab(name) {
+    createTabElement(tabCounter, name);
     switchToTab(tabCounter);
     tabCounter++;
+    saveState();
 }
 
 function removeTab(tabId) {
@@ -144,6 +147,7 @@ function removeTab(tabId) {
         const firstTab = Array.from(tabData.keys())[0];
         switchToTab(firstTab);
     }
+    saveState();
 }
 
 function switchToTab(tabId) {
@@ -158,54 +162,59 @@ function switchToTab(tabId) {
         panel.classList.add('hidden');
     });
     document.getElementById(`panel-${tabId}`).classList.remove('hidden');
-    
+
     currentTab = tabId;
+    saveState();
 }
 
 // Sound management
 function loadSound(input, tabId) {
     const file = input.files[0];
     if (!file) return;
-    
-    const soundId = `sound-${soundCounter++}`;
-    const url = URL.createObjectURL(file);
-    const audio = new Audio(url);
-    
-    // Create sound card
-    const soundCard = createSoundCard(soundId, file.name, audio, tabId);
-    
-    // Replace the empty slot
-    const grid = document.getElementById(`grid-${tabId}`);
-    const emptySlot = input.parentElement;
-    // Replace the old empty slot with the newly created sound card
-    emptySlot.replaceWith(soundCard);
-    
-    // Create new empty slot
-    const newEmptySlot = document.createElement('div');
-    newEmptySlot.className = 'empty-slot';
-    newEmptySlot.innerHTML = `
-        <input type="file" accept=".mp3,.wav" onchange="loadSound(this, ${tabId})">
-        <div class="empty-text">
-            <strong>Drop or Click</strong>
-            Add MP3/WAV file
-        </div>
-    `;
-    grid.appendChild(newEmptySlot);
-    
-    // Store sound data
-    const tab = tabData.get(tabId);
-    tab.sounds.set(soundId, {
-        name: file.name,
-        audio: audio,
-        isLooping: false,
-        element: soundCard,
-        volume: 1.0  // Individual volume (0.0 to 1.0)
-    });
-    
-    audioElements.set(soundId, audio);
-    
-    // Setup audio event listeners
-    setupAudioEvents(audio, soundId, tabId);
+
+    const reader = new FileReader();
+    reader.onload = () => {
+        const dataUrl = reader.result;
+
+        const soundId = `sound-${soundCounter++}`;
+        const audio = new Audio(dataUrl);
+
+        // Create sound card
+        const soundCard = createSoundCard(soundId, file.name, audio, tabId);
+
+        // Replace the empty slot
+        const grid = document.getElementById(`grid-${tabId}`);
+        const emptySlot = input.parentElement;
+        emptySlot.replaceWith(soundCard);
+
+        // Create new empty slot
+        const newEmptySlot = document.createElement('div');
+        newEmptySlot.className = 'empty-slot';
+        newEmptySlot.innerHTML = `
+            <input type="file" accept=".mp3,.wav" onchange="loadSound(this, ${tabId})">
+            <div class="empty-text">
+                <strong>Drop or Click</strong>
+                Add MP3/WAV file
+            </div>
+        `;
+        grid.appendChild(newEmptySlot);
+
+        const tab = tabData.get(tabId);
+        tab.sounds.set(soundId, {
+            name: file.name,
+            audio: audio,
+            isLooping: false,
+            element: soundCard,
+            volume: 1.0,
+            dataUrl: dataUrl
+        });
+
+        audioElements.set(soundId, audio);
+
+        setupAudioEvents(audio, soundId, tabId);
+        saveState();
+    };
+    reader.readAsDataURL(file);
 }
 
 function createSoundCard(soundId, name, audio, tabId) {
@@ -316,6 +325,7 @@ function toggleLoop(soundId, tabId) {
         sound.isLooping = !sound.isLooping;
         sound.audio.loop = sound.isLooping;
         loopBtn.classList.toggle('active', sound.isLooping);
+        saveState();
     }
 }
 
@@ -340,6 +350,7 @@ function removeSound(soundId, tabId) {
         tab.sounds.delete(soundId);
         audioElements.delete(soundId);
     }
+    saveState();
 }
 
 // Global controls
@@ -382,6 +393,7 @@ function clearCurrentPanel() {
                 </div>
             </div>
         `;
+        saveState();
     }
 }
 
@@ -394,6 +406,7 @@ function updateMasterVolume(value) {
     audioElements.forEach((audio, soundId) => {
         updateAudioVolume(soundId);
     });
+    saveState();
 }
 
 function updateSoundVolume(soundId, tabId, value) {
@@ -404,6 +417,7 @@ function updateSoundVolume(soundId, tabId, value) {
         sound.volume = value / 100;
         document.getElementById(`volumeValue-${soundId}`).textContent = value + '%';
         updateAudioVolume(soundId);
+        saveState();
     }
 }
 
@@ -421,6 +435,99 @@ function updateAudioVolume(soundId) {
         
         // Set final volume as master * individual
         audio.volume = masterVolume * soundVolume;
+    }
+}
+
+function saveState() {
+    const state = {
+        masterVolume,
+        tabCounter,
+        soundCounter,
+        currentTab,
+        tabs: []
+    };
+
+    tabData.forEach((tab, id) => {
+        const tabInfo = { id, name: tab.name, sounds: [] };
+        tab.sounds.forEach((sound, sid) => {
+            tabInfo.sounds.push({
+                id: sid,
+                name: sound.name,
+                dataUrl: sound.dataUrl,
+                volume: sound.volume,
+                isLooping: sound.isLooping
+            });
+        });
+        state.tabs.push(tabInfo);
+    });
+
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
+}
+
+function loadState() {
+    const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!saved) return;
+
+    try {
+        const state = JSON.parse(saved);
+        masterVolume = state.masterVolume ?? 1.0;
+        tabCounter = state.tabCounter ?? 1;
+        soundCounter = state.soundCounter ?? 0;
+        currentTab = state.currentTab ?? 0;
+
+        document.getElementById('masterVolume').value = Math.round(masterVolume * 100);
+        document.getElementById('masterVolumeValue').textContent = Math.round(masterVolume * 100) + '%';
+
+        const tabContainer = document.querySelector('.tab-container');
+        const addTabBtn = document.querySelector('.add-tab');
+        tabContainer.querySelectorAll('.tab').forEach(t => t.remove());
+        document.querySelectorAll('.panel-content').forEach(p => p.remove());
+        tabData.clear();
+        audioElements.clear();
+
+        state.tabs.forEach(tab => {
+            createTabElement(tab.id, tab.name);
+            const grid = document.getElementById(`grid-${tab.id}`);
+            grid.innerHTML = '';
+
+            tab.sounds.forEach(s => {
+                const audio = new Audio(s.dataUrl);
+                audio.loop = s.isLooping;
+                const card = createSoundCard(s.id, s.name, audio, tab.id);
+                grid.appendChild(card);
+
+                tabData.get(tab.id).sounds.set(s.id, {
+                    name: s.name,
+                    audio,
+                    isLooping: s.isLooping,
+                    element: card,
+                    volume: s.volume,
+                    dataUrl: s.dataUrl
+                });
+
+                audioElements.set(s.id, audio);
+                setupAudioEvents(audio, s.id, tab.id);
+                document.getElementById(`loop-${s.id}`).classList.toggle('active', s.isLooping);
+                document.getElementById(`volume-${s.id}`).value = Math.round(s.volume * 100);
+                document.getElementById(`volumeValue-${s.id}`).textContent = Math.round(s.volume * 100) + '%';
+                updateAudioVolume(s.id);
+            });
+
+            const emptySlot = document.createElement('div');
+            emptySlot.className = 'empty-slot';
+            emptySlot.innerHTML = `
+                <input type="file" accept=".mp3,.wav" onchange="loadSound(this, ${tab.id})">
+                <div class="empty-text">
+                    <strong>Drop or Click</strong>
+                    Add MP3/WAV file
+                </div>
+            `;
+            grid.appendChild(emptySlot);
+        });
+
+        switchToTab(currentTab);
+    } catch (e) {
+        console.error('Failed to load state', e);
     }
 }
 
@@ -451,6 +558,7 @@ document.getElementById('tabModal').addEventListener('click', (e) => {
 
 // Initialize first tab with rename functionality
 document.addEventListener('DOMContentLoaded', () => {
+    loadState();
     const firstTabSpan = document.querySelector('[data-tab="0"] span');
     if (firstTabSpan) {
         firstTabSpan.ondblclick = (e) => {


### PR DESCRIPTION
## Summary
- add `LOCAL_STORAGE_KEY` constant
- create `createTabElement` helper and refactor tab creation
- store and load soundboard state via `localStorage`
- save state after relevant UI actions
- restore saved tabs, sounds and volume settings on page load

## Testing
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_e_687ade8df058832f8a960cb50a390bac