### PR TITLE
Fix slider drag interference

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -252,6 +252,19 @@ function createSoundCard(soundId, name, audio, tabId) {
     const titleEl = card.querySelector('.sound-title');
     titleEl.ondblclick = () => startRenameSound(soundId, tabId);
 
+    // Prevent dragging the card when interacting with the volume slider
+    const volumeSlider = card.querySelector(`#volume-${soundId}`);
+    if (volumeSlider) {
+        volumeSlider.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            card.draggable = false;
+        });
+        const enableDrag = () => { card.draggable = true; };
+        volumeSlider.addEventListener('pointerup', enableDrag);
+        volumeSlider.addEventListener('pointercancel', enableDrag);
+        volumeSlider.addEventListener('pointerleave', enableDrag);
+    }
+
     setupDragAndDrop(card);
     return card;
 }


### PR DESCRIPTION
## Summary
- stop card dragging when the volume slider is used

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aecb90f94832f84ed4a8bab29191e